### PR TITLE
feat: Adds support for the AirQuality endpoint

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -44,29 +44,38 @@ module Types
       argument :query, String, description: 'The search term e.g. "St. James"', required: true
     end
 
+    field :get_air_quality, Tfl::Entities::LondonAirForecastType, null: true do
+      description 'Gets air quality data feed'
+    end
+
     def journey_meta_modes
       @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
       @tfl.journey.modes
     end
 
     def get_accident_stats(params)
-      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'], log_level: 'ERROR')
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
       @tfl.accident_stats.details(params[:year])
     end
 
     def get_all_bike_points
-      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'], log_level: 'ERROR')
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
       @tfl.bike_point.locations
     end
 
     def get_bike_point(params)
-      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'], log_level: 'ERROR')
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
       @tfl.bike_point.location params[:id]
     end
 
     def search_bike_points(params)
-      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'], log_level: 'ERROR')
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
       @tfl.bike_point.search params[:query]
+    end
+
+    def get_air_quality
+      @tfl = TflApi::Client.new(app_id: ENV['TFL_APP_ID'], app_key: ENV['TFL_APP_KEY'], host: ENV['TFL_APP_BASE'])
+      @tfl.air_quality.details
     end
   end
 end

--- a/app/graphql/types/tfl/entities/current_forecast_type.rb
+++ b/app/graphql/types/tfl/entities/current_forecast_type.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module Tfl
+    module Entities
+      class CurrentForecastType < Types::BaseObject
+        field :$id, String, null: true
+        field :$type, String, null: true
+        field :forecastType, String, null: true
+        field :forecastID, String, null: true
+        field :forecastBand, String, null: true
+        field :forecastSummary, String, null: true
+        field :nO2Band, String, null: true
+        field :o3Band, String, null: true
+        field :pM10Band, String, null: true
+        field :pM25Band, String, null: true
+        field :sO2Band, String, null: true
+        field :forecastText, String, null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/tfl/entities/london_air_forecast_type.rb
+++ b/app/graphql/types/tfl/entities/london_air_forecast_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Types
+  module Tfl
+    module Entities
+      class LondonAirForecastType < Types::BaseObject
+        field :$id, String, null: true
+        field :$type, String, null: true
+        field :updatePeriod, String, null: true
+        field :updateFrequency, String, null: true
+        field :forecastUrl, String, null: true
+        field :disclaimerText, String, null: true
+        field :currentForecast, [Types::Tfl::Entities::CurrentForecastType, null: true], null: true
+      end
+    end
+  end
+end

--- a/spec/graphql/types/tfl/entities/current_forecast_type.spec.rb
+++ b/spec/graphql/types/tfl/entities/current_forecast_type.spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Types::Tfl::Entities::CurrentForecastType do
+  subject { described_class }
+
+  it { is_expected.to have_field(:$id).of_type('String') }
+  it { is_expected.to have_field(:$type).of_type('String') }
+  it { is_expected.to have_field(:forecastType).of_type('String') }
+  it { is_expected.to have_field(:forecastID).of_type('String') }
+  it { is_expected.to have_field(:forecastBand).of_type('String') }
+  it { is_expected.to have_field(:forecastSummary).of_type('String') }
+  it { is_expected.to have_field(:nO2Band).of_type('String') }
+  it { is_expected.to have_field(:o3Band).of_type('String') }
+  it { is_expected.to have_field(:pM10Band).of_type('String') }
+  it { is_expected.to have_field(:pM25Band).of_type('String') }
+  it { is_expected.to have_field(:sO2Band).of_type('String') }
+  it { is_expected.to have_field(:forecastText).of_type('String') }
+end

--- a/spec/graphql/types/tfl/entities/london_air_forecast_type_spec.rb
+++ b/spec/graphql/types/tfl/entities/london_air_forecast_type_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Types::Tfl::Entities::LondonAirForecastType do
+  subject { described_class }
+
+  it { is_expected.to have_field(:$id).of_type('String') }
+  it { is_expected.to have_field(:$type).of_type('String') }
+  it { is_expected.to have_field(:updatePeriod).of_type('String') }
+  it { is_expected.to have_field(:updateFrequency).of_type('String') }
+  it { is_expected.to have_field(:forecastUrl).of_type('String') }
+  it { is_expected.to have_field(:disclaimerText).of_type('String') }
+  it { is_expected.to have_field(:currentForecast).of_type('[CurrentForecast]') }
+end

--- a/spec/graphql/types/tfl/enums/category_type_spec.rb
+++ b/spec/graphql/types/tfl/enums/category_type_spec.rb
@@ -3,35 +3,35 @@
 require 'rails_helper'
 
 describe Types::Tfl::Enums::CategoryType do
-  subject { described_class }
+  subject(:enum) { described_class }
 
   it { is_expected.to respond_to(:values) }
 
   it 'is expected to define an UNDEFINED value' do
-    expect(subject.values).to include('UNDEFINED')
+    expect(enum.values).to include('UNDEFINED')
   end
 
   it 'is expected to define an REALTIME value' do
-    expect(subject.values).to include('REALTIME')
+    expect(enum.values).to include('REALTIME')
   end
 
   it 'is expected to define a PLANNEDWORK value' do
-    expect(subject.values).to include('PLANNEDWORK')
+    expect(enum.values).to include('PLANNEDWORK')
   end
 
   it 'is expected to define a INFORMATION value' do
-    expect(subject.values).to include('INFORMATION')
+    expect(enum.values).to include('INFORMATION')
   end
 
   it 'is expected to define a EVENT value' do
-    expect(subject.values).to include('EVENT')
+    expect(enum.values).to include('EVENT')
   end
 
   it 'is expected to define a CROWDING value' do
-    expect(subject.values).to include('CROWDING')
+    expect(enum.values).to include('CROWDING')
   end
 
   it 'is expected to define a STATUSALERT value' do
-    expect(subject.values).to include('STATUSALERT')
+    expect(enum.values).to include('STATUSALERT')
   end
 end

--- a/spec/graphql/types/tfl/enums/datetime_type_spec.rb
+++ b/spec/graphql/types/tfl/enums/datetime_type_spec.rb
@@ -3,15 +3,15 @@
 require 'rails_helper'
 
 describe Types::Tfl::Enums::DateTimeType do
-  subject { described_class }
+  subject(:enum) { described_class }
 
   it { is_expected.to respond_to(:values) }
 
   it 'is expected to define an ARRIVING value' do
-    expect(subject.values).to include('ARRIVING')
+    expect(enum.values).to include('ARRIVING')
   end
 
   it 'is expected to define a DEPARTING value' do
-    expect(subject.values).to include('DEPARTING')
+    expect(enum.values).to include('DEPARTING')
   end
 end

--- a/spec/graphql/types/tfl/enums/route_type_spec.rb
+++ b/spec/graphql/types/tfl/enums/route_type_spec.rb
@@ -3,39 +3,39 @@
 require 'rails_helper'
 
 describe Types::Tfl::Enums::RouteType do
-  subject { described_class }
+  subject(:enum) { described_class }
 
   it { is_expected.to respond_to(:values) }
 
   it 'is expected to define an ALL value' do
-    expect(subject.values).to include('ALL')
+    expect(enum.values).to include('ALL')
   end
 
   it 'is expected to define an UNKNOWN value' do
-    expect(subject.values).to include('UNKNOWN')
+    expect(enum.values).to include('UNKNOWN')
   end
 
   it 'is expected to define a CYCLE_SUPERHIGHWAYS value' do
-    expect(subject.values).to include('CYCLE_SUPERHIGHWAYS')
+    expect(enum.values).to include('CYCLE_SUPERHIGHWAYS')
   end
 
   it 'is expected to define a QUIETWAYS value' do
-    expect(subject.values).to include('QUIETWAYS')
+    expect(enum.values).to include('QUIETWAYS')
   end
 
   it 'is expected to define a CYCLEWAYS value' do
-    expect(subject.values).to include('CYCLEWAYS')
+    expect(enum.values).to include('CYCLEWAYS')
   end
 
   it 'is expected to define a MINI_HOLLANDS value' do
-    expect(subject.values).to include('MINI_HOLLANDS')
+    expect(enum.values).to include('MINI_HOLLANDS')
   end
 
   it 'is expected to define a CENTRAL_LONDON_GRID value' do
-    expect(subject.values).to include('CENTRAL_LONDON_GRID')
+    expect(enum.values).to include('CENTRAL_LONDON_GRID')
   end
 
   it 'is expected to define a STREETSPACE_ROUTE value' do
-    expect(subject.values).to include('STREETSPACE_ROUTE')
+    expect(enum.values).to include('STREETSPACE_ROUTE')
   end
 end

--- a/spec/graphql/types/tfl/enums/sky_direction_description_type_spec.rb
+++ b/spec/graphql/types/tfl/enums/sky_direction_description_type_spec.rb
@@ -3,39 +3,39 @@
 require 'rails_helper'
 
 describe Types::Tfl::Enums::SkyDirectionDescriptionType do
-  subject { described_class }
+  subject(:enum) { described_class }
 
   it { is_expected.to respond_to(:values) }
 
   it 'is expected to define an NORTH value' do
-    expect(subject.values).to include('NORTH')
+    expect(enum.values).to include('NORTH')
   end
 
   it 'is expected to define an NORTHEAST value' do
-    expect(subject.values).to include('NORTHEAST')
+    expect(enum.values).to include('NORTHEAST')
   end
 
   it 'is expected to define a EAST value' do
-    expect(subject.values).to include('EAST')
+    expect(enum.values).to include('EAST')
   end
 
   it 'is expected to define a SOUTHEAST value' do
-    expect(subject.values).to include('SOUTHEAST')
+    expect(enum.values).to include('SOUTHEAST')
   end
 
   it 'is expected to define a SOUTH value' do
-    expect(subject.values).to include('SOUTH')
+    expect(enum.values).to include('SOUTH')
   end
 
   it 'is expected to define a SOUTHWEST value' do
-    expect(subject.values).to include('SOUTHWEST')
+    expect(enum.values).to include('SOUTHWEST')
   end
 
   it 'is expected to define a WEST value' do
-    expect(subject.values).to include('WEST')
+    expect(enum.values).to include('WEST')
   end
 
   it 'is expected to define a NORTHWEST value' do
-    expect(subject.values).to include('NORTHWEST')
+    expect(enum.values).to include('NORTHWEST')
   end
 end

--- a/spec/graphql/types/tfl/enums/status_type_spec.rb
+++ b/spec/graphql/types/tfl/enums/status_type_spec.rb
@@ -3,35 +3,35 @@
 require 'rails_helper'
 
 describe Types::Tfl::Enums::StatusType do
-  subject { described_class }
+  subject(:enum) { described_class }
 
   it { is_expected.to respond_to(:values) }
 
   it 'is expected to define an ALL value' do
-    expect(subject.values).to include('ALL')
+    expect(enum.values).to include('ALL')
   end
 
   it 'is expected to define an UNKNOWN value' do
-    expect(subject.values).to include('UNKNOWN')
+    expect(enum.values).to include('UNKNOWN')
   end
 
   it 'is expected to define a OPEN value' do
-    expect(subject.values).to include('OPEN')
+    expect(enum.values).to include('OPEN')
   end
 
   it 'is expected to define a IN_PROGRESS value' do
-    expect(subject.values).to include('IN_PROGRESS')
+    expect(enum.values).to include('IN_PROGRESS')
   end
 
   it 'is expected to define a PLANNED value' do
-    expect(subject.values).to include('PLANNED')
+    expect(enum.values).to include('PLANNED')
   end
 
   it 'is expected to define a NOT_OPEN value' do
-    expect(subject.values).to include('NOT_OPEN')
+    expect(enum.values).to include('NOT_OPEN')
   end
 
   it 'is expected to define a PLANNED___SUBJECT_TO_FEASIBILITY_AND_CONSULTATION_ value' do
-    expect(subject.values).to include('PLANNED___SUBJECT_TO_FEASIBILITY_AND_CONSULTATION_')
+    expect(enum.values).to include('PLANNED___SUBJECT_TO_FEASIBILITY_AND_CONSULTATION_')
   end
 end

--- a/spec/graphql/types/tfl/enums/track_type_spec.rb
+++ b/spec/graphql/types/tfl/enums/track_type_spec.rb
@@ -3,39 +3,39 @@
 require 'rails_helper'
 
 describe Types::Tfl::Enums::TrackType do
-  subject { described_class }
+  subject(:enum) { described_class }
 
   it { is_expected.to respond_to(:values) }
 
   it 'is expected to define an CYCLESUPERHIGHWAY value' do
-    expect(subject.values).to include('CYCLESUPERHIGHWAY')
+    expect(enum.values).to include('CYCLESUPERHIGHWAY')
   end
 
   it 'is expected to define an CANALTOWPATH value' do
-    expect(subject.values).to include('CANALTOWPATH')
+    expect(enum.values).to include('CANALTOWPATH')
   end
 
   it 'is expected to define a QUIETROAD value' do
-    expect(subject.values).to include('QUIETROAD')
+    expect(enum.values).to include('QUIETROAD')
   end
 
   it 'is expected to define a PROVISIONFORCYCLISTS value' do
-    expect(subject.values).to include('PROVISIONFORCYCLISTS')
+    expect(enum.values).to include('PROVISIONFORCYCLISTS')
   end
 
   it 'is expected to define a BUSYROADS value' do
-    expect(subject.values).to include('BUSYROADS')
+    expect(enum.values).to include('BUSYROADS')
   end
 
   it 'is expected to define a NONE value' do
-    expect(subject.values).to include('NONE')
+    expect(enum.values).to include('NONE')
   end
 
   it 'is expected to define a PUSHBIKE value' do
-    expect(subject.values).to include('PUSHBIKE')
+    expect(enum.values).to include('PUSHBIKE')
   end
 
   it 'is expected to define a QUIETWAY value' do
-    expect(subject.values).to include('QUIETWAY')
+    expect(enum.values).to include('QUIETWAY')
   end
 end

--- a/spec/requests/graphql/air_quality_spec.rb
+++ b/spec/requests/graphql/air_quality_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Graphql::AirQuality', type: :request do
+  describe 'getAirQuality' do
+    let(:query) do
+      %(
+        {
+          getAirQuality {
+            updatePeriod
+            currentForecast {
+              pM10Band
+            }
+          }
+        }
+      )
+    end
+
+    let(:json) { JSON.parse(response.body) }
+    let(:object) { json['data']['getAirQuality'] }
+
+    before do
+      VCR.use_cassette('air_quality/authorised_client_details') do
+        post graphql_path, params: { query: query }
+      end
+    end
+
+    it 'returns a 200' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns an Entities::LondonAirForecast object' do
+      expect(object).to match_response_schema('tfl/entities/londonForecast')
+    end
+  end
+end

--- a/spec/schemas/tfl/entities/londonForecast.json
+++ b/spec/schemas/tfl/entities/londonForecast.json
@@ -1,0 +1,39 @@
+{
+  "definitions": {
+    "londonForecast": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string"},
+        "type": { "type": "string" },
+        "updatePeriod": { "type": "string" },
+        "updateFrequency": { "type": "string" },  
+        "foreCastUrl": { "type": "string" },
+        "disclaimerText": { "type": "string" },
+        "currentForeCast": { 
+          "type": "array",
+          "items": {
+            "$ref": "#/defintions/currentForecast"
+          }
+        }
+      }
+    }
+  },
+  "currentForecast": {
+    "type": "object",
+    "properties": {
+      "id": { "type": "string"},
+      "type": { "type": "string" },
+      "forecastType": { "type": "string" },
+      "forecastID": { "type": "string" },
+      "forecastBand": { "type": "string" },
+      "forecastSummary": { "type": "string" },
+      "nO2Band": { "type": "string" },
+      "o3Band": { "type": "string" },
+      "pM10Band": { "type": "string" },
+      "pM25Band": { "type": "string" },
+      "sO2Band": { "type": "string" },
+      "forecastText": { "type": "string" }
+    }
+  },
+  "$ref": "#/definitions/londonForecast"
+}


### PR DESCRIPTION
Introduces new types LondonAirForecast and CurrentForecast. These are not documented in the OpenAPI spec but are defined when you call the API directly. Includes all specs and support files.

Changes elsewhere were rubocop formatting.

Closes #73 
Closes #83 
Closes #82 